### PR TITLE
Apply hunks when renaming from patch files

### DIFF
--- a/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameNoHunks.patch
+++ b/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameNoHunks.patch
@@ -1,0 +1,4 @@
+diff --git a/RenameNoHunks b/nested/subdir/Renamed
+similarity index 100%
+rename from RenameNoHunks
+rename to nested/subdir/Renamed

--- a/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameNoHunks_PostImage
+++ b/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameNoHunks_PostImage
@@ -1,0 +1,4 @@
+line1
+line2
+line3
+line4

--- a/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameNoHunks_PreImage
+++ b/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameNoHunks_PreImage
@@ -1,0 +1,4 @@
+line1
+line2
+line3
+line4

--- a/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameWithHunks.patch
+++ b/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameWithHunks.patch
@@ -1,0 +1,13 @@
+diff --git a/RenameWithHunks b/nested/subdir/Renamed
+similarity index 75%
+rename from RenameWithHunks
+rename to nested/subdir/Renamed
+index 0000000..de98044
+--- a/RenameWithHunks
++++ b/nested/subdir/Renamed
+@@ -1,4 +1,4 @@
+ line1
+-line2
++lineB
+ line3
+ line4

--- a/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameWithHunks_PostImage
+++ b/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameWithHunks_PostImage
@@ -1,0 +1,4 @@
+line1
+lineB
+line3
+line4

--- a/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameWithHunks_PreImage
+++ b/org.eclipse.jgit.test/tst-rsrc/org/eclipse/jgit/diff/RenameWithHunks_PreImage
@@ -1,0 +1,4 @@
+line1
+line2
+line3
+line4

--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/ApplyCommandTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/ApplyCommandTest.java
@@ -273,6 +273,26 @@ public class ApplyCommandTest extends RepositoryTestCase {
 		assertFalse(new File(db.getWorkTree(), "NonASCIIDel").exists());
 	}
 
+	@Test
+	public void testRenameNoHunks() throws Exception {
+		ApplyResult result = init("RenameNoHunks", true, true);
+		assertEquals(1, result.getUpdatedFiles().size());
+		assertEquals(new File(db.getWorkTree(), "RenameNoHunks"), result.getUpdatedFiles()
+				.get(0));
+		checkFile(new File(db.getWorkTree(), "nested/subdir/Renamed"),
+				b.getString(0, b.size(), false));
+	}
+
+	@Test
+	public void testRenameWithHunks() throws Exception {
+		ApplyResult result = init("RenameWithHunks", true, true);
+		assertEquals(1, result.getUpdatedFiles().size());
+		assertEquals(new File(db.getWorkTree(), "RenameWithHunks"), result.getUpdatedFiles()
+				.get(0));
+		checkFile(new File(db.getWorkTree(), "nested/subdir/Renamed"),
+				b.getString(0, b.size(), false));
+	}
+
 	private static byte[] readFile(final String patchFile) throws IOException {
 		final InputStream in = getTestResource(patchFile);
 		if (in == null) {

--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/ApplyCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/ApplyCommand.java
@@ -151,6 +151,9 @@ public class ApplyCommand extends GitCommand<ApplyResult> {
 						throw new PatchApplyException(MessageFormat.format(
 								JGitText.get().renameFileFailed, f, dest), e);
 					}
+					if (!fh.getHunks().isEmpty()) {
+						apply(dest, fh);
+					}
 					break;
 				case COPY:
 					f = getFile(fh.getOldPath(), false);


### PR DESCRIPTION
JGit discards diffs if there was a rename, which is bad.